### PR TITLE
Convert object from Time to Int as required by DynamoDB.  

### DIFF
--- a/build.rb
+++ b/build.rb
@@ -127,7 +127,7 @@ def write_master_ip(table_name, key, ip)
         ":rc" => 0,
         ":val" => ip,
         ":time" => update_time.to_i,
-        ":timeout" => (update_time - [(num_instances * 2).to_i, 45].min),
+        ":timeout" => (update_time - [(num_instances * 2).to_i, 45].min).to_i,
         ":num_min_reads" => num_instances - 1
       }
     )


### PR DESCRIPTION
Fixes "unsupported type, expected Hash, Array, Set, String, Numeric, IO, true, false, or nil, got Time" error when executing build.rb.
